### PR TITLE
Use wrapped MPI symbols from NGSolve

### DIFF
--- a/cutint/cutintegral.cpp
+++ b/cutint/cutintegral.cpp
@@ -163,7 +163,7 @@ TSCAL CutIntegral :: T_CutIntegrate (const ngcomp::MeshAccess & ma,
 		  		AtomicAdd(sum, HSum(lsum));
 		  	}
 		  });
-		  return ma.GetCommunicator().AllReduce(sum, MPI_SUM);
+		  return ma.GetCommunicator().AllReduce(sum, NG_MPI_SUM);
     } catch (ExceptionNOSIMD e) {
       cout << IM(6) << e.What()
            << "switching to non-SIMD evaluation" << endl;
@@ -201,7 +201,7 @@ TSCAL CutIntegral :: T_CutIntegrate (const ngcomp::MeshAccess & ma,
       AtomicAdd(sum,lsum);
     }
   });
-  return ma.GetCommunicator().AllReduce(sum, MPI_SUM);
+  return ma.GetCommunicator().AllReduce(sum, NG_MPI_SUM);
 }
 
 

--- a/cutint/python_cutint.cpp
+++ b/cutint/python_cutint.cpp
@@ -101,7 +101,7 @@ void ExportNgsx_cutint(py::module &m)
               if (element_wise)
                 result = py::cast(element_sum);
               else
-  						  result = py::cast(ma->GetCommunicator().AllReduce(sum, MPI_SUM));
+  						  result = py::cast(ma->GetCommunicator().AllReduce(sum, NG_MPI_SUM));
 	
   					  return result;
             } catch (ExceptionNOSIMD e) {
@@ -158,7 +158,7 @@ void ExportNgsx_cutint(py::module &m)
           if (element_wise) {
             result = py::cast(element_sum);
           } else {
-            result = py::cast(ma->GetCommunicator().AllReduce(sum, MPI_SUM));
+            result = py::cast(ma->GetCommunicator().AllReduce(sum, NG_MPI_SUM));
           }
           return result;
         },

--- a/xfem/cutinfo.cpp
+++ b/xfem/cutinfo.cpp
@@ -193,9 +193,9 @@ namespace ngcomp
       
     if (ma->GetCommunicator().Size() > 1)
     {
-      ma->AllReduceNodalData (NT_VERTEX, neg_vertex, MPI_LOR);
-      ma->AllReduceNodalData (NT_EDGE, neg_edge, MPI_LOR);
-      ma->AllReduceNodalData (NT_FACE, neg_face, MPI_LOR);
+      ma->AllReduceNodalData (NT_VERTEX, neg_vertex, NG_MPI_LOR);
+      ma->AllReduceNodalData (NT_EDGE, neg_edge, NG_MPI_LOR);
+      ma->AllReduceNodalData (NT_FACE, neg_face, NG_MPI_LOR);
     }
     
     if (ma->GetDimension() == 3) {

--- a/xfem/xFESpace.cpp
+++ b/xfem/xFESpace.cpp
@@ -357,9 +357,9 @@ namespace ngcomp
       // Array<bool> active_edge_old(active_edge);
       // Array<bool> active_face_old(active_face);
       
-      ma->AllReduceNodalData (NT_VERTEX, active_vertex, MPI_LOR);
-      ma->AllReduceNodalData (NT_EDGE, active_edge, MPI_LOR);
-      ma->AllReduceNodalData (NT_FACE, active_face, MPI_LOR);
+      ma->AllReduceNodalData (NT_VERTEX, active_vertex, NG_MPI_LOR);
+      ma->AllReduceNodalData (NT_EDGE, active_edge, NG_MPI_LOR);
+      ma->AllReduceNodalData (NT_FACE, active_face, NG_MPI_LOR);
 
       // debug only:
       // for (int i = 0; i < ma->GetNV(); i++)


### PR DESCRIPTION
NGSolve (dev version, no release yet) now supports run-time dispatch to different MPI-versions. The MPI symbols are now wrapped and need to be prefixed with `NG_`.