### PR TITLE
Update NGSolve, fix CI pipelines

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,16 +14,12 @@ jobs:
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14] # windows-latest, 
+        os: [ubuntu-latest, macos-13] # windows-latest,
         include:
           - os: windows-2019
             cibw-arch: AMD64
             cmake-generator: "Visual Studio 16 2019"
             cmake_generator_platform: "x64"
-          - os: windows-2019
-            cibw-arch: x86
-            cmake-generator: "Visual Studio 16 2019"
-            cmake_generator_platform: "Win32"        
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=8", "toml", "scikit-build-core>=0.3.3", "pybind11_stubgen", "cmake>=3.26.1", "ngsolve>=6.2.2403.post94.dev0"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=8", "toml", "scikit-build-core>=0.3.3", "pybind11_stubgen", "cmake>=3.26.1", "ngsolve>=6.2.2404.post2"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -37,6 +37,7 @@ test = ["pytest"]
 testpaths = ["tests"]
 
 [tool.cibuildwheel]
+#build-verbosity = 1
 skip = """
   pp*
   *_i686


### PR DESCRIPTION
- Require ngsolve>=6.2.2402.post2
- Build mac packages only on macos-13 (builds universal2 suporting both x86_64 and arm64)
- Disable 32bit Windows build