### PR TITLE
fix deprecation warings

### DIFF
--- a/spacetime/python_spacetime.cpp
+++ b/spacetime/python_spacetime.cpp
@@ -225,7 +225,7 @@ docu missing
   
 
   py::class_<TimeVariableCoefficientFunction, shared_ptr<TimeVariableCoefficientFunction>, CoefficientFunction>(m, "TimeVariableCoefficientFunction")
-          .def("__init__", [] () -> shared_ptr<TimeVariableCoefficientFunction> { return make_shared<TimeVariableCoefficientFunction>(); })
+          .def(py::init([] () -> shared_ptr<TimeVariableCoefficientFunction> { return make_shared<TimeVariableCoefficientFunction>(); }))
           .def("FixTime", &TimeVariableCoefficientFunction::FixTime)
           .def("UnfixTime", &TimeVariableCoefficientFunction::UnfixTime)
           .def("IsFixed", [] (shared_ptr<TimeVariableCoefficientFunction> self) -> bool {

--- a/utils/python_utils.cpp
+++ b/utils/python_utils.cpp
@@ -1,3 +1,4 @@
+#include <prolongation.hpp>
 #include <python_ngstd.hpp>
 
 /// from ngsolve
@@ -293,11 +294,10 @@ evaluates to true the CoefficientFunction will evaluate as 1, otherwise as 0.
 
 Similar functionality (also for facets) can be obtained with IndicatorCF.
 )raw_string"))
-    .def("__init__",
-         [](BitArrayCoefficientFunction *instance, shared_ptr<BitArray> ba)
+    .def(py::init([](shared_ptr<BitArray> ba) -> shared_ptr<BitArrayCoefficientFunction>
          {
-           new (instance) BitArrayCoefficientFunction (ba);
-         },
+           return make_shared<BitArrayCoefficientFunction> (ba);
+         }),
          py::arg("bitarray")
       );
 
@@ -367,11 +367,11 @@ As is asks the fespace for dofs to vertices at several occasions the
 current implementation is not very fast and should be primarily used
 for prototype and testing...
 )raw_string"))
-    .def("__init__",
-         [](P1Prolongation *instance, shared_ptr<MeshAccess> ma)
+    .def(py::init(
+         [](shared_ptr<MeshAccess> ma) -> shared_ptr<P1Prolongation>
          {
-           new (instance) P1Prolongation (ma);
-         },
+           return make_shared< P1Prolongation> (ma);
+         }),
          py::arg("mesh"))
     .def("Update",
          [](shared_ptr<P1Prolongation> p1p, shared_ptr<FESpace> fes)
@@ -389,11 +389,11 @@ As is asks the fespace for dofs to vertices at several occasions the
 current implementation is not very fast and should be primarily used
 for prototype and testing...
 )raw_string"))
-    .def("__init__",
-         [](P2Prolongation *instance, shared_ptr<MeshAccess> ma)
+    .def(py::init(
+         [](shared_ptr<MeshAccess> ma) -> shared_ptr<P2Prolongation>
          {
-           new (instance) P2Prolongation (ma);
-         },
+           return make_shared< P2Prolongation> (ma);
+         }),
          py::arg("mesh"))
     .def("Update",
          [](shared_ptr<P2Prolongation> p2p, shared_ptr<FESpace> fes)
@@ -412,11 +412,11 @@ As is asks the fespace for dofs to vertices at several occasions the
 current implementation is not very fast and should be primarily used
 for prototype and testing...
 )raw_string"))
-    .def("__init__",
-         [](P2CutProlongation *instance, shared_ptr<MeshAccess> ma)
+    .def(py::init(
+         [](shared_ptr<MeshAccess> ma) -> shared_ptr<P2CutProlongation>
          {
-           new (instance) P2CutProlongation (ma);
-         },
+           return make_shared<P2CutProlongation> (ma);
+         }),
          py::arg("mesh"))
     .def("Update",
          [](shared_ptr<P2CutProlongation> p2p, shared_ptr<FESpace> fes)
@@ -429,11 +429,11 @@ for prototype and testing...
     py::class_< CompoundProlongation, shared_ptr<CompoundProlongation>, Prolongation>
     ( m, "CompoundProlongation", 
      docu_string(R"raw_string(prolongation for compound spaces)raw_string"))
-     .def("__init__",
-          [](CompoundProlongation *instance, const FESpace *fes)
+     .def(py::init(
+          [](const FESpace *fes) -> shared_ptr<CompoundProlongation>
           {
-            new (instance) CompoundProlongation( dynamic_cast<const CompoundFESpace*>(fes) );
-          },
+            return make_shared<CompoundProlongation> (dynamic_cast<const CompoundFESpace*>(fes));
+          }),
           py::arg("compoundFESpace"))
       .def("Update", &CompoundProlongation::Update, py::arg("fespace"))
       .def ("Prolongate", &CompoundProlongation::ProlongateInline, py::arg("finelevel"), py::arg("vec"))


### PR DESCRIPTION
In debug builds, pybind11 has issued warinings:
```
<frozen importlib._bootstrap>:488: FutureWarning: pybind11-bound class 'xfem.xfem.P1Prolongation' is using an old-style placement-new '__init__' which has been deprecated. See the upgrade guide in pybind11's docs. This message is only visible when compiled in debug mode.
<frozen importlib._bootstrap>:488: FutureWarning: pybind11-bound class 'xfem.xfem.P2Prolongation' is using an old-style placement-new '__init__' which has been deprecated. See the upgrade guide in pybind11's docs. This message is only visible when compiled in debug mode.
<frozen importlib._bootstrap>:488: FutureWarning: pybind11-bound class 'xfem.xfem.P2CutProlongation' is using an old-style placement-new '__init__' which has been deprecated. See the upgrade guide in pybind11's docs. This message is only visible when compiled in debug mode.
<frozen importlib._bootstrap>:488: FutureWarning: pybind11-bound class 'xfem.xfem.CompoundProlongation' is using an old-style placement-new '__init__' which has been deprecated. See the upgrade guide in pybind11's docs. This message is only visible when compiled in debug mode.
<frozen importlib._bootstrap>:488: FutureWarning: pybind11-bound class 'xfem.xfem.CutInfo' is using an old-style placement-new '__init__' which has been deprecated. See the upgrade guide in pybind11's docs. This message is only visible when compiled in debug mode.
<frozen importlib._bootstrap>:488: FutureWarning: pybind11-bound class 'xfem.xfem.ElementAggregation' is using an old-style placement-new '__init__' which has been deprecated. See the upgrade guide in pybind11's docs. This message is only visible when compiled in debug mode.
<frozen importlib._bootstrap>:488: FutureWarning: pybind11-bound class 'xfem.xfem.MultiLevelsetCutInfo' is using an old-style placement-new '__init__' which has been deprecated. See the upgrade guide in pybind11's docs. This message is only visible when compiled in debug mode.
<frozen importlib._bootstrap>:488: FutureWarning: pybind11-bound class 'xfem.xfem.TimeVariableCoefficientFunction' is using an old-style placement-new '__init__' which has been deprecated. See the upgrade guide in pybind11's docs. This message is only visible when compiled in debug mode.
```
This commit moves to the new way of defining py::init methods.